### PR TITLE
chore: pass resource when saving auth server metadata

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -71,9 +71,9 @@ export interface OAuthClientProvider {
     state?(): string | Promise<string>;
 
     /**
-     * If implemented, this permits the OAuth client to save the authorization server metadata.
+     * If implemented, this permits the OAuth client to save the authorization server metadata and resource.
      */
-    saveAuthorizationServerMetadata?(metadata?: OAuthMetadata): void | Promise<void>;
+    saveAuthorizationServerMetadataAndResource?(metadata?: OAuthMetadata, resource?: URL): void | Promise<void>;
 
     /**
      * Loads information about this OAuth client, as registered already with the
@@ -428,8 +428,8 @@ async function authInternal(
         fetchFn
     });
 
-    if (provider.saveAuthorizationServerMetadata) {
-        await provider.saveAuthorizationServerMetadata(metadata);
+    if (provider.saveAuthorizationServerMetadataAndResource) {
+        await provider.saveAuthorizationServerMetadataAndResource(metadata, resource);
     }
 
     // Handle client registration if needed


### PR DESCRIPTION
Related to : https://github.com/dust-tt/tasks/issues/5741

To be compliant with RFC 8707, save the authorization server `resource` to be able to include it in the oauth redirect URL.